### PR TITLE
Separate local and prod nginx files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     container_name: frontend
     ports:
       - "3000:80"
+    volumes:
+      - ./front-end/nginx.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - backend
     restart: unless-stopped

--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY --from=build /app/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/nginx.prod.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/front-end/nginx.prod.conf
+++ b/front-end/nginx.prod.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
nginx.prod.conf is used by Digital Ocean since Digital Ocean already handles the /api routing and doesn't have the concept of 'backend' (comes from docker-compose.yml)

API status from deployment:
<img width="2722" height="1716" alt="image" src="https://github.com/user-attachments/assets/f11b0f8f-3a7a-4b47-b932-3f5eccfe0791" />
