### PR TITLE
Add temporary 'Store Resume' section

### DIFF
--- a/app/services/resume_service.py
+++ b/app/services/resume_service.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+from bson import ObjectId, errors as bson_errors
+from gridfs import GridFS
 from app.extensions import mongo
+
 
 class ResumeService:
     @staticmethod
@@ -11,6 +15,40 @@ class ResumeService:
         mongo.db.highlights.update_one(
             {"document_id": document_id},
             {"$set": {"highlights": highlights}},
-            upsert=True
+            upsert=True,
         )
 
+    @staticmethod
+    def save_resume_pdf(file_storage):
+        """Store an uploaded PDF in GridFS and a metadata record in MongoDB."""
+        fs = GridFS(mongo.db)
+        file_storage.stream.seek(0)
+        file_id = fs.put(
+            file_storage.read(),
+            filename=file_storage.filename,
+            content_type=file_storage.mimetype or "application/pdf",
+        )
+        doc = {
+            "filename": file_storage.filename,
+            "content_type": file_storage.mimetype or "application/pdf",
+            "file_id": file_id,
+            "created_at": datetime.utcnow(),
+        }
+        result = mongo.db.resumes.insert_one(doc)
+        return str(result.inserted_id)
+
+    @staticmethod
+    def get_resume_pdf(resume_id):
+        """Fetch metadata and PDF stream by resumeId."""
+        try:
+            object_id = ObjectId(resume_id)
+        except (bson_errors.InvalidId, TypeError):
+            return None, None
+
+        doc = mongo.db.resumes.find_one({"_id": object_id})
+        if not doc:
+            return None, None
+
+        fs = GridFS(mongo.db)
+        file_obj = fs.get(doc["file_id"])
+        return doc, file_obj

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -30,6 +30,9 @@
         <li>
           <a href="{{ url_for('resume_form.upload_resume') }}">Resume Form</a>
         </li>
+        <li>
+          <a href="{{ url_for('resume.store_resume') }}">Store Resume</a>
+        </li>
         <li><a href="{{ url_for('profile.profile_home') }}">Profile</a></li>
         <li>
           <a

--- a/app/templates/resume_store.html
+++ b/app/templates/resume_store.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %} {% block title %}Store Resume PDF{% endblock %}
+{% block content %}
+<article>
+  <h2>Store a Resume PDF</h2>
+  <p>
+    Upload a PDF and it will be stored in MongoDB. You'll get a
+    <code>resumeId</code> you can use at
+    <code>/resume/feedback/&lt;resumeId&gt;</code>.
+  </p>
+
+  <form method="post" enctype="multipart/form-data">
+    <label for="resume">Resume PDF</label>
+    <input
+      type="file"
+      id="resume"
+      name="resume"
+      accept="application/pdf"
+      required
+    />
+    <button type="submit">Upload to MongoDB</button>
+  </form>
+
+  {% if resume_id %}
+  <hr />
+  <p><strong>resumeId:</strong> {{ resume_id }}</p>
+  <div class="grid">
+    <a
+      href="{{ url_for('resume.get_resume_pdf_file', resume_id=resume_id) }}"
+      role="button"
+      class="secondary"
+    >
+      View stored PDF
+    </a>
+    <a
+      href="{{ url_for('resume.resume_feedback', resume_id=resume_id) }}"
+      role="button"
+    >
+      Open in Feedback
+    </a>
+  </div>
+  {% endif %}
+</article>
+{% endblock %}

--- a/app/views/resume_views.py
+++ b/app/views/resume_views.py
@@ -1,17 +1,33 @@
-from flask import Blueprint, render_template, send_from_directory, jsonify, request
+import io
+from flask import (
+    Blueprint,
+    render_template,
+    send_from_directory,
+    jsonify,
+    request,
+    flash,
+    url_for,
+    send_file,
+)
 from app.services.resume_service import ResumeService
 
 resume_bp = Blueprint("resume", __name__)
 
 
-@resume_bp.route("/resume/feedback")
-def resume_feedback():
-    """Resume feedback submission page - allows users to highlight and comment on the resume"""
-    document_id = "/static/pdf/jakes-resume.pdf" # TODO: Should be passed in as param
+@resume_bp.route("/resume/feedback/<resume_id>")
+def resume_feedback(resume_id):
+    """Resume feedback page - view a stored resume and leave comments on it."""
+    if not resume_id:
+        return jsonify({"error": "resumeId is required"}), 400
+
+    doc, _file = ResumeService.get_resume_pdf(resume_id)
+    if not _file:
+        return jsonify({"error": "Resume not found"}), 404
+
     return render_template(
         "resume_viewer.html",
-        document_id=document_id,
-        page_title="Submit Resume Feedback",
+        document_id=url_for("resume.get_resume_pdf_file", resume_id=resume_id),
+        page_title=f"Resume Feedback - {doc.get('filename', 'Resume')}",
     )
 
 
@@ -41,3 +57,37 @@ def save_highlights():
 
     ResumeService.save_highlights(document_id, highlights)
     return jsonify({"status": "success"}), 200
+
+
+@resume_bp.route("/resume/store", methods=["GET", "POST"])
+def store_resume():
+    """Simple page to upload a PDF and store it in MongoDB (GridFS)."""
+    resume_id = None
+    if request.method == "POST":
+        file = request.files.get("resume")
+        if not file or file.filename == "":
+            flash("Please select a PDF to upload.")
+        elif not file.filename.lower().endswith(".pdf"):
+            flash("Only PDF files are supported right now.")
+        else:
+            resume_id = ResumeService.save_resume_pdf(file)
+            flash(
+                "Resume stored successfully. Use this ID with /resume/feedback/<resumeId>."
+            )
+    return render_template("resume_store.html", resume_id=resume_id)
+
+
+@resume_bp.route("/resume/<resume_id>/pdf")
+def get_resume_pdf_file(resume_id):
+    """Stream the stored PDF from MongoDB for viewing/downloading."""
+    doc, file_obj = ResumeService.get_resume_pdf(resume_id)
+    if not file_obj:
+        return jsonify({"error": "Resume not found"}), 404
+
+    return send_file(
+        file_obj,
+        mimetype=doc.get("content_type", "application/pdf"),
+        download_name=doc.get("filename", "resume.pdf"),
+        as_attachment=False,
+        conditional=True,
+    )


### PR DESCRIPTION
Build out the logic to store resumes on MongoDB, which for now lives in its own section but will be hooked up to after submitting resume information.

https://github.com/user-attachments/assets/ca15f333-ac4e-458d-865d-75b65b3fd8c7

