### PR TITLE
Deploy only after successful push to main

### DIFF
--- a/.github/workflows/docker-cicd.yml
+++ b/.github/workflows/docker-cicd.yml
@@ -9,7 +9,11 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    # Deploy only when Web App CI succeeded on a push to main (merged PRs land as pushes)
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Previously, the Docker CI/CD job fired for any successful “Web App CI” run, so deployments were happening from PR checks. Now we deploy only when the CI workflow was triggered by a push to main (i.e., after a PR is merged).