### PR TITLE
Remove the resume selection dropdown

### DIFF
--- a/app/services/resume_service.py
+++ b/app/services/resume_service.py
@@ -6,24 +6,57 @@ from app.extensions import mongo
 
 class ResumeService:
     @staticmethod
+    def _parse_datetime(value):
+        """Parse ISO strings or datetime objects into datetime; returns None on failure."""
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                # Allow trailing Z
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _extract_first_highlight_timestamp(highlights):
+        """Find the earliest created_at timestamp across nested highlights."""
+        earliest = None
+        if not isinstance(highlights, dict):
+            return None
+
+        for page_highlights in highlights.values():
+            if not isinstance(page_highlights, list):
+                continue
+            for highlight in page_highlights:
+                if not isinstance(highlight, dict):
+                    continue
+                ts = ResumeService._parse_datetime(highlight.get("created_at"))
+                if ts and (earliest is None or ts < earliest):
+                    earliest = ts
+        return earliest
+
+    @staticmethod
     def get_highlights(document_id, reviewer_id=None):
         query = {"document_id": document_id}
         if reviewer_id:
             query["reviewer_id"] = reviewer_id
-            
+
         doc = mongo.db.highlights.find_one(query)
         return doc.get("highlights", {}) if doc else {}
 
     @staticmethod
     def get_all_reviews(document_id):
-        # returns a list of all review documents for this resume
-        cursor = mongo.db.highlights.find({"document_id": document_id})
+        # returns a list of all review documents for this resume, sorted by first highlight
+        cursor = mongo.db.highlights.find({"document_id": document_id}).sort(
+            "first_highlight_created_at", 1
+        )
         reviews = []
         for doc in cursor:
             reviews.append(
                 {
-                "reviewer_id": doc.get("reviewer_id"),
-                "reviewer_name": doc.get("reviewer_name", "Anonymous"),
+                    "reviewer_id": doc.get("reviewer_id"),
+                    "reviewer_name": doc.get("reviewer_name", "Anonymous"),
                     "highlights": doc.get("highlights", {}),
                 }
             )
@@ -37,8 +70,15 @@ class ResumeService:
         query = {"document_id": document_id}
         if reviewer_id:
             query["reviewer_id"] = reviewer_id
-            
-        update_data = {"highlights": highlights, "document_id": document_id}
+
+        # Compute earliest highlight timestamp for sorting
+        earliest = ResumeService._extract_first_highlight_timestamp(highlights)
+
+        update_data = {
+            "highlights": highlights,
+            "document_id": document_id,
+            "first_highlight_created_at": earliest,
+        }
         if reviewer_id:
             update_data["reviewer_id"] = reviewer_id
         if reviewer_name:
@@ -48,8 +88,8 @@ class ResumeService:
 
     @staticmethod
     def get_user_resumes(user_id):
-        """Get all resumes owned by a user"""
-        cursor = mongo.db.resumes.find({"user_id": user_id})
+        """Get all resumes owned by a user (oldest first, so newest is on the right)"""
+        cursor = mongo.db.resumes.find({"user_id": user_id}).sort("created_at", 1)
         resumes = []
         for doc in cursor:
             resume_id = str(doc.get("_id"))
@@ -58,12 +98,36 @@ class ResumeService:
                     "_id": resume_id,
                     # use stored path if present; otherwise fall back to streaming route
                     "resume_path": doc.get("resume_path") or f"/resume/{resume_id}/pdf",
-                "title": doc.get("title", "Untitled Resume"),
+                    "title": doc.get("title", "Untitled Resume"),
                     "created_at": doc.get("created_at"),
                 }
             )
         return resumes
-    
+
+    @staticmethod
+    def get_user_resume_entries(user_id):
+        """Get all resumes for a user with their reviews, ready for the template."""
+        user_resumes = ResumeService.get_user_resumes(user_id)
+        resume_entries = []
+        for resume in user_resumes:
+            rid = resume.get("_id")
+            created_at = resume.get("created_at")
+            created_at_iso = (
+                created_at.isoformat()
+                if isinstance(created_at, datetime)
+                else created_at
+            )
+            resume_entries.append(
+                {
+                    "_id": rid,
+                    "resume_path": resume.get("resume_path"),
+                    "title": resume.get("title"),
+                    "created_at": created_at_iso,
+                    "reviews": ResumeService.get_all_reviews(rid),
+                }
+            )
+        return resume_entries
+
     @staticmethod
     def get_resume_by_id(resume_id):
         """Get a specific resume by ID"""

--- a/app/static/css/resume_reviews.css
+++ b/app/static/css/resume_reviews.css
@@ -1,12 +1,14 @@
-/* Profile Page - Grid Layout */
 .resume-viewer-container {
     display: grid;
-    grid-template-columns: 80px 1fr 300px 80px;
-    /* Prev | Resume | Comments | Next */
+    grid-template-columns: 64px minmax(0, 1fr) 340px 64px; /* Prev | Resume | Comments | Next */
     gap: 1rem;
+    justify-content: center;
+    align-items: stretch;
     height: calc(100vh - 100px);
     overflow: hidden;
     padding: 1rem;
+    max-width: 1500px;
+    margin: 0 auto;
 }
 
 /* Nav Buttons */
@@ -14,6 +16,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    padding: 0;
 }
 
 .nav-btn {
@@ -27,15 +30,17 @@
     padding: 0;
 }
 
-/* PDF Viewer Area */
 #pdf-viewer {
     background-color: var(--pico-background-color);
     overflow: auto;
     border-radius: var(--pico-border-radius);
     box-shadow: var(--pico-card-box-shadow);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 0.75rem;
 }
 
-/* Comments Sidebar */
 aside#comments-sidebar {
     display: flex;
     flex-direction: column;

--- a/app/static/js/resume_viewer.js
+++ b/app/static/js/resume_viewer.js
@@ -15,6 +15,7 @@
 (function () {
   function createResumeViewer({
     pdfUrl,
+    pdfData,
     scale = 1.5,
     containerId = "viewer",
     renderHighlightsForPage,
@@ -91,12 +92,15 @@
     }
 
     async function renderAll() {
-      pdfDocument = await pdfjsLib.getDocument({
-        url: pdfUrl,
-        cMapUrl:
-          "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/cmaps/",
-        cMapPacked: true,
-      }).promise;
+      const source = pdfData ? { data: pdfData } : { url: pdfUrl };
+      pdfDocument = await pdfjsLib
+        .getDocument({
+          ...source,
+          cMapUrl:
+            "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/cmaps/",
+          cMapPacked: true,
+        })
+        .promise;
 
       const viewer = document.getElementById(containerId);
       viewer.innerHTML = "";

--- a/app/templates/resume_feedback.html
+++ b/app/templates/resume_feedback.html
@@ -434,6 +434,7 @@
             rects: rects,
             text: selectedText,
             comment: "",
+            created_at: new Date().toISOString(),
         };
 
         currentHighlightData = {

--- a/app/templates/resume_reviews.html
+++ b/app/templates/resume_reviews.html
@@ -8,21 +8,7 @@
 {% endblock %}
 
 {% block main %}
-<!-- Resume Selector -->
-<div style="max-width: 1200px; margin: 0 auto; padding: 20px;">
-  <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 20px;">
-    <label for="resume-selector" style="font-weight: bold;">Select Resume:</label>
-    <select id="resume-selector" class="form-control" style="max-width: 300px;">
-      {% for resume in user_resumes %}
-      <option value="{{ resume._id }}" {% if resume._id==current_resume_id %}selected{% endif %}>
-        {{ resume.title }}
-      </option>
-      {% endfor %}
-    </select>
-  </div>
-</div>
-
-<div class="resume-viewer-container">
+<div class="resume-viewer-container" style="margin-top: 20px;">
 
   <!-- Column 1: Previous Button -->
   <div class="nav-col">
@@ -37,7 +23,7 @@
   <!-- Column 3: Comments Sidebar -->
   <aside id="comments-sidebar">
     <div class="reviewer-header">
-      <small>Reviewer</small>
+      <small id="version-label">Loading version...</small>
       <h5 id="reviewer-name" style="margin:0;">Loading...</h5>
     </div>
 
@@ -55,26 +41,60 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script src="{{ url_for('static', filename='js/resume_viewer.js') }}"></script>
 <script>
-  const documentId = {{ resume_id | tojson }}; // resume_id logical key
-  const pdfUrl = {{ resume_path | tojson }}; // streaming URL for PDF
-  let reviews = {{ reviews | tojson }} || []; // array of { reviewer_id, reviewer_name, highlights }
+  /* eslint-disable */
+  const resumeEntries = JSON.parse('{{ resume_entries | tojson | safe }}');
+  const currentResumeId = JSON.parse('{{ current_resume_id | tojson | safe }}');
+  let currentResumeIndex = Math.max(
+    0,
+    resumeEntries.findIndex((r) => r._id === currentResumeId)
+  );
+  if (currentResumeIndex === -1) currentResumeIndex = 0;
   let currentReviewIndex = 0;
 
   pdfjsLib.GlobalWorkerOptions.workerSrc =
     "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js";
   const PDF_SCALE = 1.5;
   let pdfDocument = null;
+  let viewerApi = null;
+  const pdfCache = new Map();
 
-  // Handle resume selection change
-  document.addEventListener('DOMContentLoaded', function () {
-    const resumeSelector = document.getElementById('resume-selector');
-    if (resumeSelector) {
-      resumeSelector.addEventListener('change', function () {
-        const selectedId = this.value;
-        window.location.href = '/resume-reviews?resume_id=' + selectedId;
-      });
+  async function getPdfData(url) {
+    if (pdfCache.has(url)) {
+      // pdf.js may transfer the underlying buffer to a worker, so return a copy
+      const cached = pdfCache.get(url);
+      return cached.slice();
     }
-  });
+    const response = await fetch(url);
+    const buffer = await response.arrayBuffer();
+    const data = new Uint8Array(buffer);
+    pdfCache.set(url, data);
+    return data.slice();
+  }
+
+  function getCurrentEntry() {
+    return resumeEntries[currentResumeIndex] || null;
+  }
+
+  function getCurrentReviews() {
+    const entry = getCurrentEntry();
+    return (entry && entry.reviews) || [];
+  }
+
+  function updateVersionDisplay() {
+    const versionLabel = document.getElementById("version-label");
+    const prevBtn = document.getElementById("prev-btn");
+    const nextBtn = document.getElementById("next-btn");
+    const entry = getCurrentEntry();
+    if (!entry) {
+      versionLabel.textContent = "No resume";
+      prevBtn.disabled = true;
+      nextBtn.disabled = true;
+      return;
+    }
+    versionLabel.textContent = `${entry.title || "Resume"} (${currentResumeIndex + 1}/${resumeEntries.length})`;
+    prevBtn.disabled = currentResumeIndex === 0;
+    nextBtn.disabled = currentResumeIndex === resumeEntries.length - 1;
+  }
 
   // helper to create highlight rectangles
   function createHighlightRect(bounds, highlightId = null) {
@@ -101,6 +121,7 @@
   function renderHighlights(pageNum, viewport, highlightLayer) {
     highlightLayer.innerHTML = "";
 
+    const reviews = getCurrentReviews();
     const currentReview = reviews[currentReviewIndex];
     if (!currentReview) return;
 
@@ -155,30 +176,37 @@
 
   // main PDF render
   async function render() {
-    const viewer = createResumeViewer({
-      pdfUrl,
+    const entry = getCurrentEntry();
+    if (!entry) {
+      const viewer = document.getElementById("viewer");
+      if (viewer) viewer.innerHTML = "<p>No resumes found.</p>";
+      return;
+    }
+
+    const pdfData = await getPdfData(entry.resume_path);
+
+    viewerApi = createResumeViewer({
+      pdfData,
       scale: PDF_SCALE,
       renderHighlightsForPage: (pageNum, viewport, highlightLayer) =>
         renderHighlights(pageNum, viewport, highlightLayer),
     });
 
-    await viewer.render();
-    pdfDocument = viewer.getDocument();
+    await viewerApi.render();
+    pdfDocument = viewerApi.getDocument();
 
     // initial UI state
     updateReviewerDisplay();
+    updateVersionDisplay();
   }
 
   // update the UI for the current reviewer
   function updateReviewerDisplay() {
     const reviewerNameEl = document.getElementById("reviewer-name");
-    const prevBtn = document.getElementById("prev-btn");
-    const nextBtn = document.getElementById("next-btn");
+    const reviews = getCurrentReviews();
 
     if (reviews.length === 0) {
       reviewerNameEl.textContent = "No Reviews";
-      prevBtn.disabled = true;
-      nextBtn.disabled = true;
       renderComments(); // will clear comments
       updateAllHighlights(); // will clear highlights
       return;
@@ -186,10 +214,6 @@
 
     const currentReview = reviews[currentReviewIndex];
     reviewerNameEl.textContent = currentReview.reviewer_name || "Anonymous";
-
-    // update buttons
-    prevBtn.disabled = currentReviewIndex === 0;
-    nextBtn.disabled = currentReviewIndex === reviews.length - 1;
 
     // update content
     renderComments();
@@ -201,6 +225,7 @@
     const commentsList = document.getElementById("comments-list");
     commentsList.innerHTML = "";
 
+    const reviews = getCurrentReviews();
     const currentReview = reviews[currentReviewIndex];
     if (!currentReview) {
       commentsList.innerHTML = "<p>No comments available.</p>";
@@ -292,17 +317,19 @@
   }
 
   // event Listeners for Buttons
-  document.getElementById("prev-btn").addEventListener("click", () => {
-    if (currentReviewIndex > 0) {
-      currentReviewIndex--;
-      updateReviewerDisplay();
+  document.getElementById("prev-btn").addEventListener("click", async () => {
+    if (currentResumeIndex > 0) {
+      currentResumeIndex--;
+      currentReviewIndex = 0;
+      await render();
     }
   });
 
-  document.getElementById("next-btn").addEventListener("click", () => {
-    if (currentReviewIndex < reviews.length - 1) {
-      currentReviewIndex++;
-      updateReviewerDisplay();
+  document.getElementById("next-btn").addEventListener("click", async () => {
+    if (currentResumeIndex < resumeEntries.length - 1) {
+      currentResumeIndex++;
+      currentReviewIndex = 0;
+      await render();
     }
   });
 

--- a/app/views/resume_reviews_views.py
+++ b/app/views/resume_reviews_views.py
@@ -1,52 +1,34 @@
 from flask import Blueprint, render_template
 from flask_login import login_required, current_user
-from app.extensions import mongo
+from app.services.resume_service import ResumeService
 
 resume_reviews_bp = Blueprint("resume_reviews", __name__)
+
 
 @resume_reviews_bp.route("/resume-reviews")
 @login_required
 def resume_reviews_home():
     """Display the user's resume and all comments made on it."""
-    
-    from flask import request
-    from app.services.resume_service import ResumeService
-    
-    # Get all resumes for the current logged-in user
-    user_id = current_user.id
-    
-    # Get all resumes for this user
-    user_resumes = ResumeService.get_user_resumes(user_id)
-    
-    if not user_resumes:
+    resume_entries = ResumeService.get_user_resume_entries(current_user.id)
+
+    if not resume_entries:
         return render_template(
             "resume_reviews.html",
             user=current_user,
             error="No resumes found",
-            reviews=[],
-            user_resumes=[],
-            resume_id="",
-            resume_path=""
+            resume_entries=[],
+            current_resume_id="",
         )
-    
-    # Prefer a specific resume_id param, otherwise use the user's current pointer, otherwise first
-    selected_resume_id = request.args.get("resume_id") or getattr(current_user, "current_resume_id", None)
-    current_resume = next(
-        (resume for resume in user_resumes if resume.get("_id") == selected_resume_id),
-        user_resumes[0],
+
+    # Auto-pick the user's current resume if set, otherwise newest (last in list)
+    current_resume_id = (
+        getattr(current_user, "current_resume_id", None) or resume_entries[-1]["_id"]
     )
-    resume_id = current_resume["_id"]
-    resume_path = current_resume["resume_path"]
-    
-    # Get all reviews for the current resume
-    reviews = ResumeService.get_all_reviews(resume_id)
 
     return render_template(
         "resume_reviews.html",
         user=current_user,
-        resume_id=resume_id,
-        resume_path=resume_path,
-        reviews=reviews,
-        user_resumes=user_resumes,
-        current_resume_id=resume_id,
+        resume_entries=resume_entries,
+        current_resume_id=current_resume_id,
     )
+


### PR DESCRIPTION
- Replaced "Select Resume" dropdown with arrow navigation (← older | newer →)
- Reviews sorted chronologically by highlight creation time (stored in MongoDB)
- Added PDF caching to speed up resume switching

https://github.com/user-attachments/assets/92c49ddb-a489-408e-81fc-3e2bf7c3e276

I think this improves the user experience because they don't have to manually select a specific version. What do you think @phoebelh (since you worked on this page?) 